### PR TITLE
adding autocomplete form field attributes

### DIFF
--- a/form.html
+++ b/form.html
@@ -7,9 +7,9 @@
   <h1>Submit Your Information</h1>
   <form id="submissionForm">
     <label for="name">Name:</label>
-    <input type="text" id="name" name="name" required><br><br>
+    <input type="text" id="name" name="name" autocomplete="visitor-name" required><br><br>
     <label for="email">Email:</label>
-    <input type="email" id="email" name="email" required><br><br>
+    <input type="email" id="email" name="email" autocomplete="visitor-email" required><br><br>
     <button type="submit">Submit</button>
   </form>
 


### PR DESCRIPTION
from developer tools issues:

A form field has an id or name attribute that the browser's autofill recognizes. However, it doesn't have an autocomplete attribute assigned. This might prevent the browser from correctly autofilling the form.

To fix this issue, provide an autocomplete attribute.